### PR TITLE
Fix exception when folder variable is empty in jinja template

### DIFF
--- a/compass-mods-template.xml
+++ b/compass-mods-template.xml
@@ -133,7 +133,7 @@
 <!-- Shelf location -->
 {%- if container %}
 <location>
-  <shelfLocator> {{container}} {%- if folder|length > 1 %}, {{folder}} {%- endif %}
+  <shelfLocator> {{container}} {%- if folder is not none %}, {{folder}} {%- endif %}
   </shelfLocator>
 </location>
 {%- endif %}


### PR DESCRIPTION
Per our conversation the other day. Here is a pull request to fix the exception I was seeing when the folder variable is empty.